### PR TITLE
#162969132 A feature for deleting meetups by an admin from Questioner(UI)

### DIFF
--- a/UI/admin/meetups.html
+++ b/UI/admin/meetups.html
@@ -34,7 +34,7 @@
             <tr>
                 <th>Meetup</th>
                 <th>Time</th>
-                <th>Action</th>
+                <th colspan="2">Actions</th>
             </tr>
             <tr>
                 <td>Hackathon</td>
@@ -42,12 +42,16 @@
                 <td>
                     <button class="button" onclick="location.href='../user/questions.html'">view</button>
                 </td>
+                <td>
+                    <button class="button">delete</button>
+                </td>
             </tr>
             <tr>
                 <td>TDD</td>
                 <td>23rd January 2019 2PM</td>
                 <td>
                     <button class="button" onclick="location.href='../user/questions.html'">view</button>
+                    <td><button class="button">delete</button></td>
                 </td>
             </tr>
             <tr>
@@ -55,6 +59,7 @@
                 <td>23rd January 2019 2PM</td>
                 <td>
                     <button class="button" onclick="location.href='../user/questions.html'">view</button>
+                    <td><button class="button">delete</button></td>
                 </td>
             </tr>
             <tr>
@@ -62,17 +67,20 @@
                 <td>23rd January 2019 2PM</td>
                 <td>
                     <button class="button" onclick="location.href='../user/questions.html'">view</button>
+                    <td><button class="button">delete</button></td>
                 </td>
             </tr>
             <tr>
                 <td>TDD</td>
                 <td>23rd January 2019 2PM</td>
                 <td><button class="button" onclick="location.href='../user/questions.html'">view</button></td>
+                <td><button class="button">delete</button></td>
             </tr>
             <tr>
                 <td>Math Day</td>
                 <td>23rd January 2019 2PM</td>
                 <td><button class="button" onclick="location.href='../user/questions.html'">view</button></td>
+                <td><button class="button">delete</button></td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
### What does this PR do?
Adds a delete button for deleting a meetup from Questioner by an admin
### Description of Task to be completed?
Have the following adhered to:
1. Have a well designed delete button against meetups
2. Ensure the button color matches the theme of Questioner
### How should this be manually tested?
After cloning the repo:
* `git checkout ft-delete-meetup-162969132`
* `cd UI/admin/`
* Open meetups.html file with a browser
### Screenshots
![screenshot from 2019-01-06 13-02-29](https://user-images.githubusercontent.com/30015297/50734684-a5ccee80-11b3-11e9-9a5b-54c2571b6668.png)
### What are the relevant pivotal tracker stories?
[#162969132](https://www.pivotaltracker.com/story/show/162969132)